### PR TITLE
Changed height var name so func wasnt called

### DIFF
--- a/ratToolbox/available/mmWaves.m
+++ b/ratToolbox/available/mmWaves.m
@@ -8,7 +8,7 @@ noiseFloor = -174; % noise floor
 noiseFigure = -6; % noise figure
 cBandwidth=2160000000; % channel bandwidth in Hz
 beamwidthAngle = 15; % default beamwidth for mmWaves - may be changed during the simulation time
-height = [ 5 15 ]; % The range of heights that an mmWave basestation might be placed
+bsHeight = [ 5 15 ]; % The range of heights that an mmWave basestation might be placed
 mimo = 0; 
 % The maximum distance that the mmWave signal can still be considered as
 % received -- if a very big value is chosen, it will be adapted later given

--- a/ratToolbox/loadRATs.m
+++ b/ratToolbox/loadRATs.m
@@ -81,7 +81,7 @@ function [ BS, linkBudget, map ] = loadRATs(BS,linkBudget,map)
         end
         
         if strcmp(ratType,'femto')
-            BS.(ratName).height = height;
+            BS.(ratName).height = bsHeight;
             map.femtoDistanceThreshold = femtoDistanceThreshold;
         elseif strcmp(ratType,'macro')
             map.macroDensity = macroDensity;


### PR DESCRIPTION
Previous variable was just called "height", when ran with MATLAB 2022A it tried to call the height function instead of the correct variable.